### PR TITLE
Add Github Action for running JDBC tests by upgrading Babelfish extensions

### DIFF
--- a/.github/workflows/ci_upgrade.yml
+++ b/.github/workflows/ci_upgrade.yml
@@ -41,7 +41,6 @@ jobs:
           sudo make install
           cp /usr/local/lib/libantlr4-runtime.so.4.9.3 ~/postgres/lib/
       - name: Set env variables and build extensions
-        uses: actions/checkout@v2
         with:
           ref: BABEL_1_0_0
         run: |
@@ -82,6 +81,7 @@ jobs:
           sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';"
           sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
           sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "CALL sys.initialize_babelfish('jdbc_user');"
+          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "\dx"
           sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
       - name: Clone, build, and run tests for Postgres engine on development branch
         run: |
@@ -114,6 +114,7 @@ jobs:
           ~/postgres/bin/pg_ctl -D ~/postgres/data/ -l logfile start
           sudo ~/postgres/bin/psql -d postgres -U runner -c "ALTER EXTENSION "babelfishpg_common" UPDATE"
           sudo ~/postgres/bin/psql -d postgres -U runner -c "ALTER EXTENSION "babelfishpg_tsql" UPDATE"
+          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "\dx"
           sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
       - name: Run JDBC test framework
         timeout-minutes: 15

--- a/.github/workflows/ci_upgrade.yml
+++ b/.github/workflows/ci_upgrade.yml
@@ -41,9 +41,6 @@ jobs:
           sudo make install
           cp /usr/local/lib/libantlr4-runtime.so.4.9.3 ~/postgres/lib/
       - name: Set env variables and build extensions
-        uses: actions/checkout@v2
-        with:
-          ref: BABEL_1_0_0
         run: |
           export PG_CONFIG=~/postgres/bin/pg_config
           export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish

--- a/.github/workflows/ci_upgrade.yml
+++ b/.github/workflows/ci_upgrade.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Update extensions
         run: |
           cd ~
-          ~/postgres/bin/pg_ctl -D ~/postgres/data/ -l logfile start
+          ~/postgres/bin/pg_ctl -D ~/postgres/data/ -l logfile restart
           sudo ~/postgres/bin/psql -d postgres -U runner -c "ALTER EXTENSION "babelfishpg_common" UPDATE"
           sudo ~/postgres/bin/psql -d postgres -U runner -c "ALTER EXTENSION "babelfishpg_tsql" UPDATE"
           sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "\dx"

--- a/.github/workflows/ci_upgrade.yml
+++ b/.github/workflows/ci_upgrade.yml
@@ -41,8 +41,9 @@ jobs:
           sudo make install
           cp /usr/local/lib/libantlr4-runtime.so.4.9.3 ~/postgres/lib/
       - name: Set env variables and build extensions
+        with:
+          ref: 'BABEL_1_0_0'
         run: |
-          git checkout BABEL_1_0_0
           export PG_CONFIG=~/postgres/bin/pg_config
           export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
           export cmake=$(which cmake)

--- a/.github/workflows/ci_upgrade.yml
+++ b/.github/workflows/ci_upgrade.yml
@@ -19,7 +19,7 @@ jobs:
           git clone --branch BABEL_1_0_0__PG_13_4 https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
           sudo apt-get update
           sudo apt-get install uuid-dev openjdk-8-jre libicu-dev libxml2-dev openssl libssl-dev python-dev libossp-uuid-dev libpq-dev cmake pkg-config g++ build-essential bison 
-          cd postgresql_modified_for_babelfish_stable
+          cd postgresql_modified_for_babelfish
           ./configure --prefix=$HOME/postgres/ --with-python PYTHON=/usr/bin/python2.7 --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
           make -j 4 2>error.txt
           make install
@@ -85,7 +85,9 @@ jobs:
         run: |
           cd ../postgresql_modified_for_babelfish
           git checkout BABEL_1_X_DEV__PG_13_6
+          ./configure --prefix=$HOME/postgres/ --with-python PYTHON=/usr/bin/python2.7 --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
           make clean
+          make -j 4 2>error.txt
           make install
           make check
           cd contrib && make && sudo make install

--- a/.github/workflows/ci_upgrade.yml
+++ b/.github/workflows/ci_upgrade.yml
@@ -117,6 +117,7 @@ jobs:
         run: |
           cd ~
           ~/postgres/bin/pg_ctl -D ~/postgres/data/ -l logfile restart
+          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "\dx"
           sudo ~/postgres/bin/psql -d postgres -U runner -c "ALTER EXTENSION "babelfishpg_common" UPDATE"
           sudo ~/postgres/bin/psql -d postgres -U runner -c "ALTER EXTENSION "babelfishpg_tsql" UPDATE"
           sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "\dx"

--- a/.github/workflows/ci_upgrade.yml
+++ b/.github/workflows/ci_upgrade.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set env variables and build extensions
       - uses: actions/checkout@v2
         with:
-          ref: 'BABEL_1_0_0'
+          ref: BABEL_1_0_0
         run: |
           export PG_CONFIG=~/postgres/bin/pg_config
           export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish

--- a/.github/workflows/ci_upgrade.yml
+++ b/.github/workflows/ci_upgrade.yml
@@ -41,6 +41,7 @@ jobs:
           sudo make install
           cp /usr/local/lib/libantlr4-runtime.so.4.9.3 ~/postgres/lib/
       - name: Set env variables and build extensions
+      - uses: actions/checkout@v2
         with:
           ref: 'BABEL_1_0_0'
         run: |

--- a/.github/workflows/ci_upgrade.yml
+++ b/.github/workflows/ci_upgrade.yml
@@ -41,6 +41,9 @@ jobs:
           sudo make install
           cp /usr/local/lib/libantlr4-runtime.so.4.9.3 ~/postgres/lib/
       - name: Set env variables and build extensions
+        uses: actions/checkout@v2
+        with:
+          ref: BABEL_1_0_0
         run: |
           export PG_CONFIG=~/postgres/bin/pg_config
           export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish

--- a/.github/workflows/ci_upgrade.yml
+++ b/.github/workflows/ci_upgrade.yml
@@ -41,7 +41,7 @@ jobs:
           sudo make install
           cp /usr/local/lib/libantlr4-runtime.so.4.9.3 ~/postgres/lib/
       - name: Set env variables and build extensions
-      - uses: actions/checkout@v2
+        uses: actions/checkout@v2
         with:
           ref: BABEL_1_0_0
         run: |

--- a/.github/workflows/ci_upgrade.yml
+++ b/.github/workflows/ci_upgrade.yml
@@ -118,8 +118,8 @@ jobs:
           cd ~
           ~/postgres/bin/pg_ctl -D ~/postgres/data/ -l logfile restart
           sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "\dx"
-          sudo ~/postgres/bin/psql -d postgres -U runner -c "ALTER EXTENSION "babelfishpg_common" UPDATE"
-          sudo ~/postgres/bin/psql -d postgres -U runner -c "ALTER EXTENSION "babelfishpg_tsql" UPDATE"
+          sudo ~/postgres/bin/psql -d postgres -U runner -c "ALTER EXTENSION "babelfishpg_common" UPDATE;"
+          sudo ~/postgres/bin/psql -d postgres -U runner -c "ALTER EXTENSION "babelfishpg_tsql" UPDATE;"
           sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "\dx"
           sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
       - name: Run JDBC test framework

--- a/.github/workflows/ci_upgrade.yml
+++ b/.github/workflows/ci_upgrade.yml
@@ -40,9 +40,10 @@ jobs:
           make
           sudo make install
           cp /usr/local/lib/libantlr4-runtime.so.4.9.3 ~/postgres/lib/
-      - name: Set env variables and build extensions
+      - uses: actions/checkout@v2
         with:
           ref: BABEL_1_0_0
+      - name: Set env variables and build extensions
         run: |
           export PG_CONFIG=~/postgres/bin/pg_config
           export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
@@ -93,9 +94,11 @@ jobs:
           make install
           make check
           cd contrib && make && sudo make install
+      - uses: actions/checkout@v2
+        with:
+          ref: BABEL_1_X_DEV
       - name: Set env variables and build extensions on development branch
         run: |
-          git checkout BABEL_1_X_DEV
           export PG_CONFIG=~/postgres/bin/pg_config
           export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
           export cmake=$(which cmake)

--- a/.github/workflows/ci_upgrade.yml
+++ b/.github/workflows/ci_upgrade.yml
@@ -1,0 +1,146 @@
+name: JDBC Unit Tests
+on:
+  push:
+    branches:
+      - BABEL_1_X_DEV
+  pull_request:
+    branches:
+      - BABEL_1_X_DEV
+
+jobs:
+  extension-tests:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Clone and build Postgres engine on stable branch
+        run: |
+          cd ..
+          git clone --branch BABEL_1_0_0__PG_13_4 https://github.com/babelfish-for-postgresql/postgresql_modified_for_babelfish.git
+          sudo apt-get update
+          sudo apt-get install uuid-dev openjdk-8-jre libicu-dev libxml2-dev openssl libssl-dev python-dev libossp-uuid-dev libpq-dev cmake pkg-config g++ build-essential bison 
+          cd postgresql_modified_for_babelfish_stable
+          ./configure --prefix=$HOME/postgres/ --with-python PYTHON=/usr/bin/python2.7 --enable-debug CFLAGS="-ggdb" --with-libxml --with-uuid=ossp --with-icu
+          make -j 4 2>error.txt
+          make install
+          make check
+          cd contrib && make && sudo make install
+      - name: Copy ANTLR jar file
+        run: |
+          cd contrib/babelfishpg_tsql/antlr/thirdparty/antlr/
+          sudo cp antlr-4.9.3-complete.jar /usr/local/lib
+      - name: Compile ANTLR
+        run: |
+          cd ..
+          wget http://www.antlr.org/download/antlr4-cpp-runtime-4.9.3-source.zip
+          unzip -d antlr4 antlr4-cpp-runtime-4.9.3-source.zip 
+          cd antlr4
+          mkdir build && cd build 
+          cmake .. -D ANTLR_JAR_LOCATION=/usr/local/lib/antlr-4.9.3-complete.jar -DCMAKE_INSTALL_PREFIX=/usr/local -DWITH_DEMO=True
+          make
+          sudo make install
+          cp /usr/local/lib/libantlr4-runtime.so.4.9.3 ~/postgres/lib/
+      - name: Set env variables and build extensions
+        run: |
+          git checkout BABEL_1_0_0
+          export PG_CONFIG=~/postgres/bin/pg_config
+          export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
+          export cmake=$(which cmake)
+          cd contrib/babelfishpg_money
+          make && make install
+          cd ../babelfishpg_common
+          make && make install
+          cd ../babelfishpg_tds
+          make && make install
+          echo Now building bbf_tsql
+          cd ../babelfishpg_tsql
+          make && make install
+      - name: Install extensions
+        run: |
+          cd ~
+          curl https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
+          curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | sudo tee /etc/apt/sources.list.d/msprod.list
+          sudo apt-get install mssql-tools unixodbc-dev
+          export PATH=/opt/mssql-tools/bin:$PATH
+          ~/postgres/bin/initdb -D ~/postgres/data/
+          ~/postgres/bin/pg_ctl -D ~/postgres/data/ -l logfile start
+          cd postgres/data
+          sudo sed -i "s/#listen_addresses = 'localhost'/listen_addresses = '*'/g" postgresql.conf
+          sudo sed -i "s/#shared_preload_libraries = ''/shared_preload_libraries = 'babelfishpg_tds'/g" postgresql.conf
+          ipaddress=$(ifconfig eth0 | grep 'inet ' | cut -d: -f2 | awk '{ print $2}')
+          sudo echo "host    all             all             $ipaddress/32            trust" >> pg_hba.conf
+          ~/postgres/bin/pg_ctl -D ~/postgres/data/ -l logfile restart
+          sudo ~/postgres/bin/psql -d postgres -U runner -c "CREATE USER jdbc_user WITH SUPERUSER CREATEDB CREATEROLE PASSWORD '12345678' INHERIT;"
+          sudo ~/postgres/bin/psql -d postgres -U runner -c "DROP DATABASE IF EXISTS jdbc_testdb;"
+          sudo ~/postgres/bin/psql -d postgres -U runner -c "CREATE DATABASE jdbc_testdb OWNER jdbc_user;"
+          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "set allow_system_table_mods = on;"
+          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "CREATE EXTENSION IF NOT EXISTS "babelfishpg_tds" CASCADE;"
+          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "GRANT ALL ON SCHEMA sys to jdbc_user;"
+          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "ALTER USER jdbc_user CREATEDB;"
+          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "ALTER SYSTEM SET babelfishpg_tsql.database_name = 'jdbc_testdb';"
+          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "SELECT pg_reload_conf();"
+          sudo ~/postgres/bin/psql -d jdbc_testdb -U runner -c "CALL sys.initialize_babelfish('jdbc_user');"
+          sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
+      - name: Clone, build, and run tests for Postgres engine on development branch
+        run: |
+          cd ../postgresql_modified_for_babelfish
+          git checkout BABEL_1_X_DEV__PG_13_6
+          make clean
+          make install
+          make check
+          cd contrib && make && sudo make install
+      - name: Set env variables and build extensions on development branch
+        run: |
+          git checkout BABEL_1_X_DEV
+          export PG_CONFIG=~/postgres/bin/pg_config
+          export PG_SRC=~/work/babelfish_extensions/postgresql_modified_for_babelfish
+          export cmake=$(which cmake)
+          cd contrib/babelfishpg_money
+          make clean && make && make install
+          cd ../babelfishpg_common
+          make clean && make && make install
+          cd ../babelfishpg_tds
+          make clean && make && make install
+          echo Now building bbf_tsql
+          cd ../babelfishpg_tsql
+          make clean && make && make install
+      - name: Update extensions
+        run: |
+          cd ~
+          ~/postgres/bin/pg_ctl -D ~/postgres/data/ -l logfile start
+          sudo ~/postgres/bin/psql -d postgres -U runner -c "ALTER EXTENSION "babelfishpg_common" UPDATE"
+          sudo ~/postgres/bin/psql -d postgres -U runner -c "ALTER EXTENSION "babelfishpg_tsql" UPDATE"
+          sqlcmd -S localhost -U jdbc_user -P 12345678 -Q "SELECT @@version GO"
+      - name: Run JDBC test framework
+        timeout-minutes: 15
+        run: |
+          cd test/JDBC/
+          mvn test
+      - name: Upload log
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: postgres-log
+          path: ~/postgres/data/logfile
+      # The test summary files contain paths with ':' characters, which is not allowed with the upload-artifact actions
+      - name: Rename test summary files
+        if: ${{ failure() }}
+        run: |
+          cd test/JDBC/Info
+          timestamp=`ls -Art | tail -n 1`
+          cd $timestamp
+          mv $timestamp.diff ../output-diff.diff
+          mv "$timestamp"_runSummary.log ../run-summary.log
+      - name: Upload run summary 
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: run-summary.log
+          path: test/JDBC/Info/run-summary.log
+      - name: Upload output diff
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: output-diff.diff
+          path: test/JDBC/Info/output-diff.diff
+

--- a/.github/workflows/ci_upgrade.yml
+++ b/.github/workflows/ci_upgrade.yml
@@ -42,6 +42,7 @@ jobs:
           cp /usr/local/lib/libantlr4-runtime.so.4.9.3 ~/postgres/lib/
       - uses: actions/checkout@v2
         with:
+          repository: babelfish-for-postgresql/babelfish_extensions
           ref: BABEL_1_0_0
       - name: Set env variables and build extensions
         run: |
@@ -96,6 +97,7 @@ jobs:
           cd contrib && make && sudo make install
       - uses: actions/checkout@v2
         with:
+          repository: babelfish-for-postgresql/babelfish_extensions
           ref: BABEL_1_X_DEV
       - name: Set env variables and build extensions on development branch
         run: |


### PR DESCRIPTION
This commit adds another workflow which does the following:
1. Builds the postgres engine modified for babelfish of version 13.4
2. Builds and installs the babelfish extensions corresponding to
   BABEL_1_0_0
3. Initializes the babelfish database
4. Builds the postgres engine modified for babelfish of current dev
   version
5. Builds the babelfish extensions corresponding to version
   BABEL_1_X_DEV
6. Updates the babelfish extensions using ALTER EXTENSION ... UPDATE
7. Runs the JDBC tests

Signed-off-by: Sharu Goel <goelshar@amazon.com>